### PR TITLE
Enable to sleep in a non blocking manner

### DIFF
--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -36,7 +36,7 @@ module AsyncScheduler
     # Implementation might register the current fiber in some list of “which fiber wait until what moment”,
     # call Fiber.yield to pass control, and then in close resume the fibers whose wait period has elapsed.
     def kernel_sleep(duration = nil)
-      block(:kernel_sleep, duration)
+      block(:kernel_sleep, Time.now + duration)
       Fiber.yield
     end
 

--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -66,7 +66,7 @@ module AsyncScheduler
       while !@waitings.empty? || @blocking_cnt > 0
         first_fiber, first_timeout = @waitings.min_by{|fiber, timeout| timeout}
         if first_timeout <= Time.now
-          unblock(:_closed_fiber, first_fiber) # TODO: pass a good identifier of the fiber
+          unblock(:_closed_fiber, first_fiber) # TODO: pass a good named identifier of the fiber
           @waitings.delete(first_fiber)
         end
       end

--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -2,6 +2,12 @@ module AsyncScheduler
   # This class implements Fiber::SchedulerInterface.
   # See https://ruby-doc.org/core-3.1.0/Fiber/SchedulerInterface.html for details.
   class Scheduler
+    def initialize
+      # (key, value) = (Fiber object, timeout)
+      @waitings = {}
+    end
+
+
     # Implementation of the Fiber.schedule.
     # The method is expected to immediately run the given block of code in a separate non-blocking fiber,
     # and to return that Fiber.

--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -23,7 +23,7 @@ module AsyncScheduler
     # blocker is what we are waiting on, informational only (for debugging and logging). There are no guarantee about its value.
     # Expected to return boolean, specifying whether the blocking operation was successful or not.
     def block(blocker, timeout = nil)
-      @waiting[Fiber.current] = timeout
+      @waitings[Fiber.current] = timeout
       return true
     end
 

--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -5,7 +5,7 @@ module AsyncScheduler
     def initialize
       # (key, value) = (Fiber object, timeout)
       @waitings = {}
-      # number of blockers which blocks for good.
+      # number of blockers which blocks for good. e.g. sleeping without the timeout.
       @blocking_cnt = 0
     end
 

--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -21,6 +21,8 @@ module AsyncScheduler
     # blocker is what we are waiting on, informational only (for debugging and logging). There are no guarantee about its value.
     # Expected to return boolean, specifying whether the blocking operation was successful or not.
     def block(blocker, timeout = nil)
+      @waiting[Fiber.current] = timeout # timeout=nil signifies that it sleeps eternally.
+      return true
     end
 
     # Invoked to wake up Fiber previously blocked with block (for example, Mutex#lock calls block and Mutex#unlock calls unblock).
@@ -34,6 +36,8 @@ module AsyncScheduler
     # Implementation might register the current fiber in some list of “which fiber wait until what moment”,
     # call Fiber.yield to pass control, and then in close resume the fibers whose wait period has elapsed.
     def kernel_sleep(duration = nil)
+      block(:kernel_sleep, duration)
+      Fiber.yield
     end
 
     # Invoked by Timeout.timeout to execute the given block within the given duration.


### PR DESCRIPTION
## Why

For `Kernel#sleep` and `Mutex#sleep` to be executed in a non blocking manner.

## What 

`#initialize`, `#block`, `#unblock`, `#kernel_sleep`, and `#close` are implemented.

Instead of making a system call of `sleep` (which blocks), I detect the timeout by looping in the `#close` method.


## Proof

The snippet below is executed in around 3 seconds, not in around 9 seconds.

```rb
    thread = Thread.new do
      t = Time.now
      Fiber.set_scheduler AsyncScheduler::Scheduler.new

      Fiber.schedule do
        sleep(3)
      end
      Fiber.schedule do
        sleep(3)
      end
      Fiber.schedule do
        sleep(3)
      end
    end
    thread.join
```


(I took this approach because I am not sure of how to validate the correctness of the concurrent program now.)