### PR TITLE
Schedule and execute io_write tasks in the non blocking manner

### DIFF
--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -117,7 +117,12 @@ module AsyncScheduler
     # See IO::Buffer for an interface available to get data from buffer efficiently.
     # Expected to return number of bytes written, or, in case of an error, -errno (negated number corresponding to system's error code).
     def io_write(io, buffer, length) # returns: written length or -errnoclick to toggle source
-      result = io.write_nonblock(buffer, exception: false)
+      begin
+        result = io.write_nonblock(buffer, exception: false)
+      rescue SystemCallError => e
+        return -e.errno
+      end
+
       case result
       when :wait_writable
         # TODO: this may not write all bytes in buffer to io.

--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -78,6 +78,7 @@ module AsyncScheduler
         # When timeout of a blocker in @waitings has come,
         # the scheduler should stop `select` system call, and execute the fiber which is not blocked any more.
         while !@output_waitings.empty?
+          # TODO: using select syscall is not efficient. Use epoll/kqueue here.
           _input_ready, output_ready = IO.select([], @output_waitings.keys)
           if !output_ready.nil?
             fiber_non_blocking = @output_waitings.delete(output_ready)

--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -6,7 +6,7 @@ module AsyncScheduler
       # (key, value) = (Fiber object, timeout)
       @waitings = {}
       # (key, value) = (blocking io, Fiber object)
-      @input_waitings = {}
+      # @input_waitings = {} # TODO: uncomment this line in an appropriate PR.
       @output_waitings = {}
       # number of blockers which blocks for good. e.g. sleeping without the timeout.
       @blocking_cnt = 0

--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -76,7 +76,7 @@ module AsyncScheduler
 
         while !@output_waitings.empty?
           _input_ready, output_ready = IO.select([], @output_waitings.keys)
-          fiber_non_blocking = @output_waitings[output_ready]
+          fiber_non_blocking = @output_waitings.delete(output_ready)
           fiber_non_blocking.resume
         end
       end

--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -74,6 +74,9 @@ module AsyncScheduler
           @waitings.delete(first_fiber)
         end
 
+        # TODO: This is not necessarily an efficient way.
+        # When timeout of a blocker in @waitings has come,
+        # the scheduler should stop `select` system call, and execute the fiber which is not blocked any more.
         while !@output_waitings.empty?
           _input_ready, output_ready = IO.select([], @output_waitings.keys)
           fiber_non_blocking = @output_waitings.delete(output_ready)

--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -98,9 +98,10 @@ module AsyncScheduler
       # TODO: use timeout parameter
       # TODO?: Expected to return the subset of events that are ready immediately.
 
-      if events & IO::READABLE == IO::READABLE
-        @input_waitings[io] = Fiber.current
-      end
+      # TODO: uncomment this lines in an appropriate PR.
+      # if events & IO::READABLE == IO::READABLE
+      #   @input_waitings[io] = Fiber.current
+      # end
 
       if events & IO::WRITABLE == IO::WRITABLE
         @output_waitings[io] = Fiber.current

--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -79,8 +79,10 @@ module AsyncScheduler
         # the scheduler should stop `select` system call, and execute the fiber which is not blocked any more.
         while !@output_waitings.empty?
           _input_ready, output_ready = IO.select([], @output_waitings.keys)
-          fiber_non_blocking = @output_waitings.delete(output_ready)
-          fiber_non_blocking.resume
+          if !output_ready.nil?
+            fiber_non_blocking = @output_waitings.delete(output_ready)
+            fiber_non_blocking.resume
+          end
         end
       end
     end

--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -79,7 +79,16 @@ module AsyncScheduler
     def io_read
     end
 
-    def io_write(_, _, _)
+    # Invoked by IO#write to write length bytes to io from from a specified buffer (see IO::Buffer).
+    # The length argument is the “(minimum) length to be written”.
+    # If the IO buffer size is 8KiB, but the length specified is 1024 (1KiB), at most 8KiB will be written, but at least 1KiB will be.
+    # Generally, the only case where less data than length will be written is if there is an error writing the data.
+
+    # Specifying a length of 0 is valid and means try writing at least once, as much data as possible.
+    # Suggested implementation should try to write to io in a non-blocking manner and call io_wait if the io is not ready (which will yield control to other fibers).
+    # See IO::Buffer for an interface available to get data from buffer efficiently.
+    # Expected to return number of bytes written, or, in case of an error, -errno (negated number corresponding to system's error code).
+    def io_write(io, buffer, length) # returns: written length or -errnoclick to toggle source
     end
   end
 end

--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -73,6 +73,13 @@ module AsyncScheduler
       end
     end
 
+
+    # Invoked by IO#wait, IO#wait_readable, IO#wait_writable to ask whether the specified descriptor is ready for specified events within the specified timeout.
+    # events is a bit mask of IO::READABLE, IO::WRITABLE, and IO::PRIORITY.
+
+    # Suggested implementation should register which Fiber is waiting for which resources and immediately calling Fiber.yield to pass control to other fibers.
+    # Then, in the close method, the scheduler might dispatch all the I/O resources to fibers waiting for it.
+    # Expected to return the subset of events that are ready immediately.
     def io_wait
     end
 

--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -80,10 +80,10 @@ module AsyncScheduler
     # Suggested implementation should register which Fiber is waiting for which resources and immediately calling Fiber.yield to pass control to other fibers.
     # Then, in the close method, the scheduler might dispatch all the I/O resources to fibers waiting for it.
     # Expected to return the subset of events that are ready immediately.
-    def io_wait
+    def io_wait(io, events, timeout)
     end
 
-    def io_read
+    def io_read(io, buffer, length) # read length or -errno
     end
 
     # Invoked by IO#write to write length bytes to io from from a specified buffer (see IO::Buffer).

--- a/spec/blockings/write_spec.rb
+++ b/spec/blockings/write_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe AsyncScheduler do
+  it "writes in fibers with AsyncScheduler::Scheduler" do
+    t = Time.now
+    thread = Thread.new do
+      t = Time.now
+      Fiber.set_scheduler AsyncScheduler::Scheduler.new
+
+      Fiber.schedule do
+        File.open("./log1.txt", "w"){|f| f.write("aaa") }
+        puts '## finished writing in the first fiber'
+      end
+      Fiber.schedule do
+        File.open("./log2.txt", "w"){|f| f.write("bbb") }
+        puts '## finished writing in the second fiber'
+      end
+      Fiber.schedule do
+        File.open("./log3.txt", "w"){|f| f.write("ccc") }
+        puts '## finished writing in the third fiber'
+      end
+
+    end
+    thread.join
+    # This method should take around 3 seconds, not around 9 seconds.
+    puts "It took #{Time.now - t} seconds to run three fibers concurrently."
+  end
+end


### PR DESCRIPTION
## Why 

For output (of I/O) to be executed in a non blocking manner.

## What 

lib
- Implement `#io_write` along with `io_wait`.
- Update `#close` to execute fibers which have not been executed due to the block of outputting.
- Add a hash `@output_waitings`.  The key is an Output object and the value is a fiber which is blocked by that.

spec
- Add a spec in which each of three fibers writes to a file.

