### PR TITLE
[Fix] Write specified length from in buffer to I/O in `Scheduler#io_write`

### DIFF
--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -127,10 +127,11 @@ module AsyncScheduler
       offset = 0
 
       while offset < length || length == 0
+        write_nonblock = Fiber.new(blocking: true) do
+          io.write_nonblock(buffer, exception: false)
+        end
+
         begin
-          write_nonblock = Fiber.new(blocking: true) do
-            io.write_nonblock(buffer, exception: false)
-          end
           result = write_nonblock.resume
         rescue SystemCallError => e
           return -e.errno

--- a/spec/blockings/write_spec.rb
+++ b/spec/blockings/write_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe AsyncScheduler do
 
     end
     thread.join
-    # This method should take around 3 seconds, not around 9 seconds.
     puts "It took #{Time.now - t} seconds to run three fibers concurrently."
   end
 end

--- a/spec/blockings/write_spec.rb
+++ b/spec/blockings/write_spec.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe AsyncScheduler do
+  before do
+    File.delete("./log1.txt")
+    File.delete("./log2.txt")
+    File.delete("./log3.txt")
+  end
+
   it "writes in fibers with AsyncScheduler::Scheduler" do
     t = Time.now
     thread = Thread.new do


### PR DESCRIPTION
## Why

In the current implementation, `Scheduler#io_write` writes only once from buffer to I/O.
This does not guarantee to write specified length of bytes.


## What

- Track the offset which indicates how many bytes have been written from buffer to I/O
- Use the while loop to iterate writing to I/O until the offset signifies that the specified length has been written.



