### PR TITLE
[Fix] Specify the starting index in the buffer when writing non-blockly to i/o

### DIFF
--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -138,7 +138,7 @@ module AsyncScheduler
           # IO#read_nonblock is hooked to Scheduler#io_wait, so it has to be wrapped.
           # If IO#read_nonblock is hooked to Scheduler#io_read, this method call has to be wrapped too.
           # ref. https://docs.ruby-lang.org/ja/latest/class/IO.html#I_WRITE_NONBLOCK
-          io.write_nonblock(buffer, exception: false)
+          io.write_nonblock(buffer.get_string(offset), exception: false)
         end
 
         begin


### PR DESCRIPTION
## Why

At `io.write_nonblock(buffer.get_string, exception: false)` in `#io_write`, the scheduler tries to write the whole string in the buffer to i/o.

Since it counts how many bytes it has already written from buffer to i/o with `offset`, it should start writing from substring whose first index is the `offset`.

## What

Modify to `io.write_nonblock(buffer.get_string(offset), exception: false)`