### PR TITLE
[Fix] Enable `puts` in `Fiber.schedule` block

### DIFF
--- a/spec/blockings/read_spec.rb
+++ b/spec/blockings/read_spec.rb
@@ -15,18 +15,18 @@ RSpec.describe AsyncScheduler do
 
       Fiber.schedule do
         f1 = File.open("./log1.txt", "r"){|f| f.read() }
-        # puts '## finished reading in the first fiber: '
-        # puts f1
+        puts '## finished reading in the first fiber: '
+        puts f1
       end
       Fiber.schedule do
         f2 = File.open("./log2.txt", "r"){|f| f.read() }
-        # puts '## finished reading in the second fiber'
-        # puts f2
+        puts '## finished reading in the second fiber'
+        puts f2
       end
       Fiber.schedule do
         f3 = File.open("./log3.txt", "r"){|f| f.read() }
-        # puts '## finished reading in the third fiber'
-        # puts f3
+        puts '## finished reading in the third fiber'
+        puts f3
       end
 
     end

--- a/spec/blockings/read_spec.rb
+++ b/spec/blockings/read_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe AsyncScheduler do
         puts '## finished reading in the third fiber'
         puts f3
       end
-
     end
     thread.join
     puts "It took #{Time.now - t} seconds to run three fibers concurrently."

--- a/spec/blockings/write_spec.rb
+++ b/spec/blockings/write_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe AsyncScheduler do
         File.open("./log3.txt", "w"){|f| f.write("ccc") }
         puts '## finished writing in the third fiber'
       end
-
     end
     thread.join
     puts "It took #{Time.now - t} seconds to run three fibers concurrently."

--- a/spec/blockings/write_spec.rb
+++ b/spec/blockings/write_spec.rb
@@ -15,15 +15,15 @@ RSpec.describe AsyncScheduler do
 
       Fiber.schedule do
         File.open("./log1.txt", "w"){|f| f.write("aaa") }
-        # puts '## finished writing in the first fiber'
+        puts '## finished writing in the first fiber'
       end
       Fiber.schedule do
         File.open("./log2.txt", "w"){|f| f.write("bbb") }
-        # puts '## finished writing in the second fiber'
+        puts '## finished writing in the second fiber'
       end
       Fiber.schedule do
         File.open("./log3.txt", "w"){|f| f.write("ccc") }
-        # puts '## finished writing in the third fiber'
+        puts '## finished writing in the third fiber'
       end
 
     end


### PR DESCRIPTION
## Why

A function call `puts "at_least one_argument"` in a `Fiber.schedule` block raises an error `Errno::EAGAIN`.

## How to reproduce

(📝 Use this [repo](https://github.com/kudojp/ruby-c-extention-debug-on-linux) to reproduce with a docker container.)

Run the snippet below In the root directory of this repository.
```rb
require './lib/scheduler'
thread = Thread.new do
  t = Time.now
  Fiber.set_scheduler AsyncScheduler::Scheduler.new

  Fiber.schedule do
    puts 'some string'
  end
end
thread.join
```

It raises an error below.

```
some string#<Thread:0x0000000105bb7a28 (irb):33 run> terminated with exception (report_on_exception is true):
(irb):38:in `write': Resource temporarily unavailable @ io_writev - <STDOUT> (Errno::EAGAIN)
        from (irb):38:in `puts'
        from (irb):38:in `puts'
        from (irb):38:in `block (2 levels) in <top (required)>'
(irb):38:in `write': Resource temporarily unavailable @ io_writev - <STDOUT> (Errno::EAGAIN)
        from (irb):38:in `puts'
        from (irb):38:in `puts'
        from (irb):38:in `block (2 levels) in <top (required)>'
```

⚠️  Please note that `puts` works properly if it is called without an argument.
The error is raised when it is called with at least 1 augment.

<details>
<summary>details</summary>

```rb
require './lib/scheduler'
thread = Thread.new do
  t = Time.now
  Fiber.set_scheduler AsyncScheduler::Scheduler.new

  Fiber.schedule do
    puts
  end
end
thread.join
```

```

=> #<Thread:0x0000000105cc8db8 (irb):82 dead>
```

This does not raise an error.

</details>



# What