### PR TITLE
Fix logic in Scheduler#close

### DIFF
--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -67,14 +67,6 @@ module AsyncScheduler
     # The suggested pattern is to implement the main event loop in the close method.
     def close
       while !@waitings.empty? || @blocking_cnt > 0 || !@input_waitings.empty? || !@output_waitings.empty?
-        # TODO: Use a min heap for @waitings
-        while !@waitings.empty?
-          first_fiber, first_timeout = @waitings.min_by{|fiber, timeout| timeout}
-          break if Time.now < first_timeout
-          unblock(:_closed_fiber, first_fiber) # TODO: pass a good named identifier of the fiber
-          @waitings.delete(first_fiber)
-        end
-
         while !@input_waitings.empty? || !@output_waitings.empty?
           _, earliest_timeout = @waitings.min_by{|fiber, timeout| timeout}
           timeout =
@@ -102,6 +94,14 @@ module AsyncScheduler
               fiber_non_blocking.resume
             end
           end
+        end
+
+        # TODO: Use a min heap for @waitings
+        while !@waitings.empty?
+          first_fiber, first_timeout = @waitings.min_by{|fiber, timeout| timeout}
+          break if Time.now < first_timeout
+          unblock(:_closed_fiber, first_fiber) # TODO: pass a good named identifier of the fiber
+          @waitings.delete(first_fiber)
         end
       end
     end


### PR DESCRIPTION
## Why

In the current implementation below, `IO.select` raises an `ArgumentError(time interval must not be negative)` when ` earliest_timeout - Time.now` < 0.

```rb
    while !@waitings.empty? || @blocking_cnt > 0 || !@input_waitings.empty? || !@output_waitings.empty?
        _, earliest_timeout = @waitings.min_by{|fiber, timeout| timeout}
        inputs_ready, outputs_ready = IO.select(@input_waitings.keys, @output_waitings.keys, [], earliest_timeout - Time.now)
```


## What

To avoid the error above, if `earliest_timeout` is earlier than `Time.now`, the scheduler handles the corresponding `@waitings` event before `IO.select`. (Executing `@waitings` event immediately would also help that events with the timeouts are executed at the closer time to the specified time.)