### PR TITLE
Remove `unblock()` call in `Scheduler#close`

### DIFF
--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -106,7 +106,6 @@ module AsyncScheduler
           first_fiber, first_timeout = @waitings.min_by{|fiber, timeout| timeout}
           break if Time.now < first_timeout
           @waitings.delete(first_fiber)
-          unblock(:_closed_fiber, first_fiber) # TODO: pass a good named identifier of the fiber
         end
       end
     end


### PR DESCRIPTION
📝 Supplementary fix of https://github.com/kudojp/async_scheduler/pull/15.


## What 

Remove #unblock method call in #close method.

```rb
        while !@waitings.empty?
          first_fiber, first_timeout = @waitings.min_by{|fiber, timeout| timeout}
          break if Time.now < first_timeout
          @waitings.delete(first_fiber)
          unblock(:_closed_fiber, first_fiber) # TODO: pass a good named identifier of the fiber
        end
```


## Why

#unblock is used to delete unblocked fiber from @blockings as below.
This must not be used for the removal of fiber **from @waitings**.

```rb
    def unblock(blocker, fiber)
      # TODO: Make use of blocker.
      @blockings.delete fiber
      fiber.resume
    end
```