### PR TITLE
Raise an error when AsyncScheduler is used in multithread programming

### DIFF
--- a/lib/async_scheduler/cross_thread_usage_detector.rb
+++ b/lib/async_scheduler/cross_thread_usage_detector.rb
@@ -2,12 +2,12 @@ module CrossThreadUsageDetector
   class BelongingThreadAlreadySetError < StandardError; end
   class CrossThreadUsageError < StandardError; end
 
-  def set_belonging_thread(original_thread_object_id)
+  def set_belonging_thread
     if defined? @belonging_thread_object_id
-      raise BelongingThreadAlreadySetError.new("@belonging_thread_object_id is already set with #{@belonging_thread_object_id}, but it is attempted to set again with #{original_thread_object_id}.")
+      raise BelongingThreadAlreadySetError.new("@belonging_thread_object_id is already set with #{@belonging_thread_object_id}, but it is attempted to set again with #{Thread.current.object_id}.")
     end
 
-    @belonging_thread_object_id = original_thread_object_id
+    @belonging_thread_object_id = Thread.current.object_id
   end
 
   def validate_used_in_original_thread!

--- a/lib/async_scheduler/cross_thread_usage_detector.rb
+++ b/lib/async_scheduler/cross_thread_usage_detector.rb
@@ -1,10 +1,10 @@
 module CrossThreadUsageDetector
-  class OriginalThreadAlreadySetError < StandardError; end
+  class BelongingThreadAlreadySetError < StandardError; end
   class CrossThreadUsageError < StandardError; end
 
   def set_belonging_thread(original_thread_object_id)
     if defined? @belonging_thread_object_id
-      raise OriginalThreadAlreadySetError.new("@belonging_thread_object_id is already set with #{@belonging_thread_object_id}, but it is attempted to set again with #{original_thread_object_id}.")
+      raise BelongingThreadAlreadySetError.new("@belonging_thread_object_id is already set with #{@belonging_thread_object_id}, but it is attempted to set again with #{original_thread_object_id}.")
     end
 
     @belonging_thread_object_id = original_thread_object_id

--- a/lib/async_scheduler/cross_thread_usage_detector.rb
+++ b/lib/async_scheduler/cross_thread_usage_detector.rb
@@ -10,9 +10,9 @@ module CrossThreadUsageDetector
     @belonging_thread_object_id = original_thread_object_id
   end
 
-  def validate_used_in_original_thread!(another_thread_object_id)
-    return if @belonging_thread_object_id == another_thread_object_id
+  def validate_used_in_original_thread!
+    return if @belonging_thread_object_id == Thread.current.object_id
 
-    raise CrossThreadUsageError.new("Cross-thread usage detected. FiberScheduler was originally registered to a thread (#{@belonging_thread_object_id}), but it is attempted to be used in another thread (#{another_thread_object_id}).")
+    raise CrossThreadUsageError.new("Cross-thread usage detected. FiberScheduler was originally registered to a thread (#{@belonging_thread_object_id}), but it is attempted to be used in another thread (#{Thread.current.object_id}).")
   end
 end

--- a/lib/async_scheduler/cross_thread_usage_detector.rb
+++ b/lib/async_scheduler/cross_thread_usage_detector.rb
@@ -2,7 +2,7 @@ module CrossThreadUsageDetector
   class BelongingThreadAlreadySetError < StandardError; end
   class CrossThreadUsageError < StandardError; end
 
-  def set_belonging_thread
+  def set_belonging_thread!
     if defined? @belonging_thread_object_id
       raise BelongingThreadAlreadySetError.new("@belonging_thread_object_id is already set with #{@belonging_thread_object_id}, but it is attempted to set again with #{Thread.current.object_id}.")
     end

--- a/lib/async_scheduler/cross_thread_usage_detector.rb
+++ b/lib/async_scheduler/cross_thread_usage_detector.rb
@@ -1,0 +1,18 @@
+module CrossThreadUsageDetector
+  class OriginalThreadAlreadySetError < StandardError; end
+  class CrossThreadUsageError < StandardError; end
+
+  def set_belonging_thread(original_thread_object_id)
+    if defined? @belonging_thread_object_id
+      raise OriginalThreadAlreadySetError.new("@belonging_thread_object_id is already set with #{@belonging_thread_object_id}, but it is attempted to set again with #{original_thread_object_id}.")
+    end
+
+    @belonging_thread_object_id = original_thread_object_id
+  end
+
+  def validate_used_in_original_thread!(another_thread_object_id)
+    return if @belonging_thread_object_id == another_thread_object_id
+
+    raise CrossThreadUsageError.new("Cross-thread usage detected. FiberScheduler was originally registered to a thread (#{@belonging_thread_object_id}), but it is attempted to be used in another thread (#{another_thread_object_id}).")
+  end
+end

--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -8,7 +8,7 @@ module AsyncScheduler
     include CrossThreadUsageDetector
 
     def initialize
-      set_belonging_thread
+      set_belonging_thread!
 
       # (key, value) = (Fiber object, timeout[not nil])
       @waitings = {}

--- a/lib/async_scheduler/scheduler.rb
+++ b/lib/async_scheduler/scheduler.rb
@@ -8,7 +8,7 @@ module AsyncScheduler
     include CrossThreadUsageDetector
 
     def initialize
-      set_belonging_thread(Thread.current.object_id)
+      set_belonging_thread
 
       # (key, value) = (Fiber object, timeout[not nil])
       @waitings = {}

--- a/spec/basics/threading_spec.rb
+++ b/spec/basics/threading_spec.rb
@@ -4,8 +4,6 @@ require 'async_scheduler/cross_thread_usage_detector'
 
 RSpec.describe AsyncScheduler do
   it "can create and run a new thread in a Fiber.schedule block" do
-    Thread.abort_on_exception = false
-
     parent_thread = Thread.new do
       Fiber.set_scheduler AsyncScheduler::Scheduler.new
       Fiber.schedule do
@@ -14,9 +12,21 @@ RSpec.describe AsyncScheduler do
       end
     end
 
-    expect { parent_thread.join }.to raise_error(
-      CrossThreadUsageDetector::CrossThreadUsageError,
-      "Cross-thread usage detected. FiberScheduler was originally registered to a thread (#{parent_thread.object_id}), but it is attempted to be used in another thread (#{$child_thread.object_id})."
-    )
+    begin
+      parent_thread.join
+      raise Exception.new("This should not be reached")
+    rescue => e
+      expect(e.class).to eq(CrossThreadUsageDetector::CrossThreadUsageError)
+      expect(e.message).to eq("Cross-thread usage detected. FiberScheduler was originally registered to a thread (#{parent_thread.object_id}), but it is attempted to be used in another thread (#{$child_thread.object_id}).")
+    end
+
+    # NOTE: the reason why I don't use the following code is because:
+    #       `#{$child_thread.object_id}` in the matcher seems to be evaluated before `parent_thread.join` finishes.
+    #       When this occurs, $child_thread.object_id is not set yet and it is evaluated as 8, which is object_id of nil.
+    #
+    # expect { parent_thread.join }.to raise_error(
+    #   CrossThreadUsageDetector::CrossThreadUsageError,
+    #   "Cross-thread usage detected. FiberScheduler was originally registered to a thread (#{parent_thread.object_id}), but it is attempted to be used in another thread (#{$child_thread.object_id})."
+    # )
   end
 end

--- a/spec/basics/threading_spec.rb
+++ b/spec/basics/threading_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe AsyncScheduler do
+  it "can create and run a new thread in a Fiber.schedule block" do
+    Thread.abort_on_exception = false
+    thread = Thread.new do
+      Fiber.set_scheduler AsyncScheduler::Scheduler.new
+      Fiber.schedule do
+        Thread.new{}.join
+      end
+    end
+
+    expect{thread.join}.not_to raise_error
+  end
+end


### PR DESCRIPTION
## Why

As explained in https://github.com/kudojp/async_scheduler/issues/31#issuecomment-1345463420, AsyncSchduler is not thread-safe at https://github.com/kudojp/async_scheduler/commit/e54d9aabf1176a9433a7a94534b057250ceb771b.
As the short term solution, AsyncScheduler should raise an error when it is used in multithread programming.

## What

When instantiating AsyncScheduler instance (probably which is in the main thread.), AsyncScheduler holds the thread's object_id 🟢 as its instance variable.
When any of the instance methods of that scheduler instance is called, it validates that the current thread's object id is the same as object_id set at 🟢. If it is not the same, it raises `CrossThreadUsageError`.