### PR TITLE
Fix supported Ruby version to be only `3.1.x`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: [3.0, 3.1]
+        ruby: ['3.1']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: ruby/setup-ruby@v1

--- a/async_scheduler.gemspec
+++ b/async_scheduler.gemspec
@@ -12,7 +12,11 @@ Gem::Specification.new do |spec|
   spec.description = "This is a task scheduler which implements the FiberScheduler interface"
   spec.homepage = "https://github.com/kudojp/async_scheduler"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.0.0"
+  # The interface of FiberScheduler#io_read had a breaking change from Ruby 3.0 to 3.1.
+  # - Ruby 3.0: #io_read takes 4 arguments.
+  # - Ruby 3.1: #io_read takes 3 arguments.
+  # The implementation of scheduler#io_read in this gem takes only 3 arguments.
+  spec.required_ruby_version = "~> 3.1.0"
 
   spec.metadata["allowed_push_host"] = "TODO: Set to your gem server 'https://example.com'"
 


### PR DESCRIPTION
## Why

Current implementation of the scheduler cannot be used in Ruby ver`3.1.x`, because the scheduler of this gem accepts only 3 arguments ([src](https://github.com/kudojp/async_scheduler/blob/cfc404d0d975e73d167c448a0059393ee2ae75aa/lib/async_scheduler/scheduler.rb#L176)) on `#io_read`.

- In Ruby `3.0.x`, `io_read` is called with 4 arguments (not documented, [src](https://github.com/ruby/ruby/blob/ruby_3_0/scheduler.c#L195-L199))
- In Ruby `3.1.x`, `io_read` is called with 3 arguments ([doc](https://github.com/ruby/ruby/blob/ruby_3_1/doc/fiber.md?plain=1#L90), [src](https://github.com/ruby/ruby/blob/ruby_3_1/scheduler.c#L234-L242))
- In Ruby `3.2.x`, `io_read` is called with 3 arguments ([doc](https://github.com/ruby/ruby/blob/ruby_3_2/doc/fiber.md?plain=1#L90) is wrong, [src](https://github.com/ruby/ruby/blob/ruby_3_2/scheduler.c#L485-L493)) - _Not added to CI testing yet_


## What 

- Specify `spec.required_ruby_version = "~> 3.1.0"` in gemspec
- Remove CI testing with Ruby ver 3.0.

---

## 📝  Why this was not noticed so far.

<img width="1406" alt="image" src="https://github.com/kudojp/async_scheduler/assets/44487754/e520d77a-dc4b-42d5-8483-71f15ff17903">


The CI testing with Ruby 3.0 began to fail suddenly on some time between `Dec 13, 2022` and `Jul 4, 2023`.
I will explain the reason of this.

```.github/workflows/ci.yaml
jobs:
  test:
    strategy:
      matrix:
        os: [ubuntu-latest, macos-latest]
        ruby: [3.0, 3.1]
    runs-on: ${{ matrix.os }}
    steps:
      - uses: ruby/setup-ruby@v1
        with:
          ruby-version: ${{ matrix.ruby }}
```

### On `Dec 13, 2022` ✅

CI testing was triggered. At this time, the latest ruby was `3.1.x`.
`3.0` was interpreted as `3`, and the latest version of `3.x` (=`3.1.x`) was used.
(ref: https://github.com/actions/runner/issues/849 https://github.com/ruby/setup-ruby/issues/252).

Since `#io_read` takes 3 arguments in Ruby3.1, the CI testing did not fail.


### On `Dec 25, 2022`

Ruby 3.2 was released. At this time, the latest ruby became `3.2.x`.

### On `Jul 4, 2023` ❌

CI testing was triggered. At this time, the latest ruby was `3.2.x`.
`3.0` was interpreted as `3`, and the latest version of `3.x` (= `3.2.x`), was used.

Since `#io_read` takes 4 arguments in Ruby3.2, the CI testing failed.